### PR TITLE
Fix all GHC warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,5 +25,5 @@ before_install:
 
 script:
   - stack --no-terminal --skip-ghc-check setup
-  - stack --no-terminal --skip-ghc-check --ghc-options "-Wall -Werror" build
-  - stack --no-terminal --skip-ghc-check --ghc-options "-Wall -Werror" test
+  - stack --no-terminal --skip-ghc-check build --ghc-options "-Wall -Werror"
+  - stack --no-terminal --skip-ghc-check test  --ghc-options "-Wall -Werror"

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,5 +25,5 @@ before_install:
 
 script:
   - stack --no-terminal --skip-ghc-check setup
-  - stack --no-terminal --skip-ghc-check build
-  - stack --no-terminal --skip-ghc-check test
+  - stack --no-terminal --skip-ghc-check --ghc-options "-Wall -Werror" build
+  - stack --no-terminal --skip-ghc-check --ghc-options "-Wall -Werror" test

--- a/Text/Hastache/Aeson.hs
+++ b/Text/Hastache/Aeson.hs
@@ -10,12 +10,8 @@ module Text.Hastache.Aeson (
       jsonValueContext
     ) where
 
-import qualified Data.ByteString.Char8 as BS
 import qualified Data.Text as T
 
-import Control.Monad
-import Control.Applicative
-import qualified Data.Foldable as Foldable
 import Data.Maybe (fromMaybe)
 
 import qualified Data.Map as Map
@@ -27,7 +23,6 @@ import Data.Monoid ((<>))
 import Data.Aeson.Types
 
 import Text.Hastache
-import Text.Hastache.Context
 
 jsonValueContext :: Monad m => Value -> MuContext m
 jsonValueContext = buildMapContext . valueMap

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -6,12 +6,10 @@ import Test.Tasty
 import Test.Tasty.HUnit
 import Text.Hastache
 import Text.Hastache.Aeson
-import Text.Hastache.Context
 
 import Data.Maybe (fromJust)
-import Data.Aeson
+import Data.Aeson hiding (json)
 
-import qualified Data.ByteString.Char8 as BS
 import qualified Data.ByteString.Lazy.Char8 as LBS
 
 import Data.Text as T
@@ -43,8 +41,7 @@ tests = testGroup "Integration Tests" [
 
 assertTemplate :: LT.Text -> LBS.ByteString -> T.Text -> Assertion
 assertTemplate expectedResult json template =
-  assertEqual "Unexpected rendering result" expectedResult =<< render json template
-
-render json template =
-  let value = fromJust $ decode json
-  in hastacheStr defaultConfig template $ jsonValueContext value
+    assertEqual "Unexpected rendering result" expectedResult =<< rendered
+  where
+    value = fromJust $ decode json
+    rendered = hastacheStr defaultConfig template $ jsonValueContext value


### PR DESCRIPTION
I also added `--ghc-options "-Wall -Werror"` to the CI script.

The fixed warnings are:
- Mostly unused imports
- Shadowed declaration (`json` from Data.Aeson) was conflicting with the corresponding argument of `assertTemplate`
- Top-level binding without type declaration

I don't want to add the declaration to `render` function, because it would require to add `transformers` package to the `build-depends` section. Since it is just tests, I prefer to inline the `render` function instead.
